### PR TITLE
Use @typescript/no-useless-constructor

### DIFF
--- a/packages/eslint-config-q-base/index.js
+++ b/packages/eslint-config-q-base/index.js
@@ -65,6 +65,8 @@ module.exports = {
         message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
       },
     ],
+    "no-useless-constructor": "off",
+    "@typescript-eslint/no-useless-constructor": ["error"],
     '@typescript-eslint/no-use-before-define': ['error', { "functions": false, "classes": false, "variables": true }],
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',


### PR DESCRIPTION
The current rule is broken for typescript constructors like the following one:

```
It allows following typescript constructors:

constructor(
    public dataService: DataServiceClient,
    public systemUserContext: Context,
    public measurementSchemaId: string,
    public startAnalysisTransitionId: string,
    public completeAnalysisTransitionId: string,
    public failAnalysisTransitionId: string,
    public cancelAnalysisTransitionId: string
  ) { }
  ```

This change fixes it. 