### PR TITLE
PAG-207: no-void allowAsStatment enabled

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.4",
+  "version": "1.3.5",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/packages/eslint-config-q-base/index.js
+++ b/packages/eslint-config-q-base/index.js
@@ -67,6 +67,7 @@ module.exports = {
       },
     ],
     "no-useless-constructor": "off",
+    "no-void": ["error", { "allowAsStatement": true }],
     "@typescript-eslint/no-useless-constructor": ["error"],
     '@typescript-eslint/no-use-before-define': ['error', { "functions": false, "classes": false, "variables": true }],
     '@typescript-eslint/explicit-function-return-type': 'off',


### PR DESCRIPTION
`no-floating-promises` enables `ignoreVoid` by default. Only the rule `no-void` has to be altered.